### PR TITLE
Fix `Practical::Views` to use `@practical-computer/error-handling`

### DIFF
--- a/app/components/practical/views/form/error_list_component.rb
+++ b/app/components/practical/views/form/error_list_component.rb
@@ -8,7 +8,7 @@ class Practical::Views::Form::ErrorListComponent < Practical::Views::BaseCompone
   end
 
   def call
-    tag.ul(class: 'error-list') {
+    tag.ul(data: {'data-pf-error-container': true}) {
       safe_join(errors.map{|error| render Practical::Views::Form::ErrorListItemComponent.new(error: error) })
     }
   end

--- a/app/components/practical/views/form/error_list_item_component.rb
+++ b/app/components/practical/views/form/error_list_item_component.rb
@@ -12,9 +12,9 @@ class Practical::Views::Form::ErrorListItemComponent < Practical::Views::BaseCom
   end
 
   def call
-    tag.li(class: 'wa-flank', data: {"error-type": error.type}) {
+    tag.li(class: 'wa-flank', data: {"pf-error-type": error.type, "pf-error-visible": true}) {
       render(icon_set.error_list_icon) +
-      tag.span(error.message)
+      tag.span(error.message, "data": { "pf-error-message": true })
     }
   end
 end

--- a/app/components/practical/views/form/error_list_item_component.rb
+++ b/app/components/practical/views/form/error_list_item_component.rb
@@ -14,7 +14,7 @@ class Practical::Views::Form::ErrorListItemComponent < Practical::Views::BaseCom
   def call
     tag.li(class: 'wa-flank', data: {"pf-error-type": error.type, "pf-error-visible": true}) {
       render(icon_set.error_list_icon) +
-      tag.span(error.message, "data": { "pf-error-message": true })
+      tag.span(error.message, data: { "pf-error-message": true })
     }
   end
 end

--- a/app/components/practical/views/form/error_list_item_template_component.rb
+++ b/app/components/practical/views/form/error_list_item_template_component.rb
@@ -2,7 +2,7 @@
 
 class Practical::Views::Form::ErrorListItemTemplateComponent < Practical::Views::BaseComponent
   def call
-    tag.template(id: 'error-list-item-template') {
+    tag.template(id: 'pf-error-list-item-template') {
       render Practical::Views::Form::ErrorListItemComponent.new(error: ActiveModel::Error.new(nil, nil, nil))
     }
   end

--- a/app/components/practical/views/form/fallback_errors_section_component.rb
+++ b/app/components/practical/views/form/fallback_errors_section_component.rb
@@ -11,7 +11,8 @@ class Practical::Views::Form::FallbackErrorsSectionComponent < Practical::Views:
 
   def finalized_options
     mix({
-      class: ["error-section", "fallback-error-section", "wa-callout", "wa-danger"],
+      class: ["wa-callout", "wa-danger"],
+      data: {"pf-error-container": true, "pf-fallback-error-section": true},
       id: id
     }, @options)
   end

--- a/app/lib/practical/test/shared/memberships/controllers/organization/membership.rb
+++ b/app/lib/practical/test/shared/memberships/controllers/organization/membership.rb
@@ -160,7 +160,7 @@ module Practical::Test::Shared::Memberships::Controllers::Organization::Membersh
       end
       end
 
-      assert_response :bad_request
+      assert_response :unprocessable_entity
 
       assert_error_json_contains(
         container_id: "organization_new_membership_invitation_form_base_errors",
@@ -192,7 +192,7 @@ module Practical::Test::Shared::Memberships::Controllers::Organization::Membersh
       end
       end
 
-      assert_response :bad_request
+      assert_response :unprocessable_entity
 
       assert_error_json_contains(
         container_id: "organization_new_membership_invitation_form_base_errors",
@@ -224,7 +224,7 @@ module Practical::Test::Shared::Memberships::Controllers::Organization::Membersh
       end
       end
 
-      assert_response :bad_request
+      assert_response :unprocessable_entity
 
       assert_error_json_contains(
         container_id: "organization_new_membership_invitation_form_base_errors",
@@ -252,7 +252,7 @@ module Practical::Test::Shared::Memberships::Controllers::Organization::Membersh
         post organization_memberships_url(organization), params: params, as: :json
       end
       end
-      assert_response :bad_request
+      assert_response :unprocessable_entity
 
       assert_error_json_contains(
         container_id: "organization_new_membership_invitation_form_email_errors",
@@ -280,7 +280,7 @@ module Practical::Test::Shared::Memberships::Controllers::Organization::Membersh
         post organization_memberships_url(organization), params: params
       end
       end
-      assert_response :bad_request
+      assert_response :unprocessable_entity
 
       assert_error_dom(
         container_id: "organization_new_membership_invitation_form_email_errors",
@@ -387,7 +387,7 @@ module Practical::Test::Shared::Memberships::Controllers::Organization::Membersh
         }}
       end
 
-      assert_response :bad_request
+      assert_response :unprocessable_entity
 
       assert_error_dom(
         container_id: "generic_errors_organization_membership_form",

--- a/app/lib/practical/views/error_response.rb
+++ b/app/lib/practical/views/error_response.rb
@@ -7,14 +7,14 @@ module Practical::Views::ErrorResponse
     format.json do
       errors = Practical::Views::ErrorHandling.build_error_json(model: model, helpers: helpers)
       yield(errors) if block_given?
-      render json: errors, status: :bad_request
+      render json: errors, status: :unprocessable_entity
     end
   end
 
   def render_html_error(action:, format:)
     format.html do
       yield  if block_given?
-      render action, status: :bad_request
+      render action, status: :unprocessable_entity
     end
   end
 

--- a/lib/practical/framework/engine.rb
+++ b/lib/practical/framework/engine.rb
@@ -18,7 +18,7 @@ module Practical
         def practical_form_with(**args, &block)
           original_field_error_proc = ::ActionView::Base.field_error_proc
           ::ActionView::Base.field_error_proc = ->(html_tag, instance) { html_tag }
-          content_tag(:"practical-framework-error-handling") do
+          content_tag(:"application-error-handling") do
             form_with(**args, &block)
           end
         ensure


### PR DESCRIPTION
[`Practical::Views::ErrorResponse`: `render_json/html_error` return 422](https://github.com/practical-computer/practical/commit/e9833ad65a0ee335b64982068abba3d45c026743) 
* In order to match the status code expected by Practical Error's server-side rendering, the `render_json_error` & `render_html_error` methods need to return a status code of `422 Unprocessable Entity`

> The provided request processing functions expect a 422 response to
> indicate that the request has validation errors. It's an error, and
the response's status code should reflect that.
> See: https://github.com/practical-computer/practical-error-handling-js?tab=readme-ov-file#server-side-errors


[Shared Membership controller tests expect 422 for error responses](https://github.com/practical-computer/practical/commit/15a520151e86beef23987adbb791e02735a6b1f3) 
* In order to match the status code expected by Practical Error's server-side rendering, the `render_json_error` & `render_html_error` methods need to return a status code of `422 Unprocessable Entity`

> The provided request processing functions expect a 422 response to
> indicate that the request has validation errors. It's an error, and
the response's status code should reflect that.
> See: https://github.com/practical-computer/practical-error-handling-js?tab=readme-ov-file#server-side-errors


[`practical_form_with`: wraps form with `application-error-handling`](https://github.com/practical-computer/practical/commit/6d754c91cb20ded1e540362bf770cdbf843685a8) 
* `application-error-handling` is a Custom Element that each application can define for its specific error-handling behavior, under the assumption that `@practical-computer/practical-error-handling` is being used:
	* https://github.com/practical-computer/practical-error-handling-js?tab=readme-ov-file#extending-the-custom-elements

[Update `Practical::Views::Form` for `@practical-computer/error-handling`](https://github.com/practical-computer/practical/commit/a62d0d659063acc227c26c162b46a568527cbf6e) 
* Updated the view components for form errors to follow the conventions and apply the data attributes that `@practical-computer/error-handling` expects
	* See: https://github.com/practical-computer/practical-error-handling-js?tab=readme-ov-file#data-attributes