### PR TITLE
`InputComponent`: check & raise `FieldOptionsNotCalledError`

### DIFF
--- a/app/components/practical/views/form/input_component.rb
+++ b/app/components/practical/views/form/input_component.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Practical::Views::Form::InputComponent < Practical::Views::BaseComponent
+  class FieldOptionsNotCalledError < StandardError; end
   attr_accessor :f, :object_method, :label_options
 
   renders_one :label
@@ -17,9 +18,19 @@ class Practical::Views::Form::InputComponent < Practical::Views::BaseComponent
   end
 
   def field_options(**options)
-    mix({
+    @_field_options_called = true
+    return mix({
       "aria-describedby": field_errors_id,
       "data": {"pf-initial-load-errors": f.errors_for(object_method)&.any? }
     }, options)
+  end
+
+  def around_render
+    result = yield
+    unless @_field_options_called
+      raise FieldOptionsNotCalledError, "field_options was not called when rendering an InputComponent; which means this the input & its error container are not connected."
+    end
+
+    return result
   end
 end


### PR DESCRIPTION
* `field_options` contains essential glue code to tie an input to its error container. We can use `around_render` to check if field_options was called, and if not, raise an error so that it gets fixed ASAP
* See: https://viewcomponent.org/guide/lifecycle.html